### PR TITLE
fix: broken provider initialization from legacy default tags code

### DIFF
--- a/stackoverflow/provider.go
+++ b/stackoverflow/provider.go
@@ -49,7 +49,6 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 	var diags diag.Diagnostics
 	client := so.NewClient(&baseURL, &accessToken)
-	client.DefaultTags = convertToArray[string](d.Get("default_tags").([]interface{}))
 
 	return client, diags
 }


### PR DESCRIPTION
The provider initialization is broken due to legacy default tags code being left in accidentally.